### PR TITLE
Fixed entities not deleting themselves when uninstalling, sped up target detection state change

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2025  Joakim Sørensen @ludeeus
+Copyright (c) 2025  Zachary Graham @WestwardWinds
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -190,4 +190,3 @@ data:
 - Platforms: `sensor` (coordinates storage) and `binary_sensor` (presence)
 - Event bus: fires `zone_mapper_zone_updated` to notify platform entities of changes
 - Constants and limits are defined in `const.py` (e.g., `POLYGON_MAX_POINTS = 32`)
-

--- a/custom_components/zone_mapper/__init__.py
+++ b/custom_components/zone_mapper/__init__.py
@@ -526,3 +526,22 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """
     _ = (hass, entry)
     return True
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """
+    Remove a config entry.
+
+    Since this integration uses legacy platform loading which doesn't associate
+    entities with the config entry, we must manually clean them up from the registry.
+    """
+    _ = entry
+    registry = er.async_get(hass)
+    entities_to_remove = [
+        entry.entity_id
+        for entry in registry.entities.values()
+        if entry.platform == DOMAIN
+    ]
+
+    for entity_id in entities_to_remove:
+        registry.async_remove(entity_id)

--- a/custom_components/zone_mapper/binary_sensor.py
+++ b/custom_components/zone_mapper/binary_sensor.py
@@ -312,7 +312,7 @@ class ZonePresenceBinarySensor(BinarySensorEntity):
         """Handle state change of a tracked entity."""
         self.async_schedule_update_ha_state(force_refresh=True)
 
-    def update(self) -> None:
+    async def async_update(self) -> None:
         """Fetch new state data for the sensor."""
         zone_def, rotation_raw = self._resolve_zone_definition()
 
@@ -379,7 +379,6 @@ class ZonePresenceBinarySensor(BinarySensorEntity):
             if x_val == 0.0 and y_val == 0.0:
                 return None
             return x_val, y_val
-        # Unreachable but keeps structure explicit.
 
     @staticmethod
     def _states_are_valid(x_state: State | None, y_state: State | None) -> bool:

--- a/custom_components/zone_mapper/binary_sensor.py
+++ b/custom_components/zone_mapper/binary_sensor.py
@@ -370,9 +370,16 @@ class ZonePresenceBinarySensor(BinarySensorEntity):
         if x_state is None or y_state is None:
             return None
         try:
-            return float(x_state.state), float(y_state.state)
+            x_val = float(x_state.state)
+            y_val = float(y_state.state)
         except (TypeError, ValueError):
             return None
+        else:
+            # Ignore origin (0,0) so default or uninitialized readings are skipped.
+            if x_val == 0.0 and y_val == 0.0:
+                return None
+            return x_val, y_val
+        # Unreachable but keeps structure explicit.
 
     @staticmethod
     def _states_are_valid(x_state: State | None, y_state: State | None) -> bool:

--- a/custom_components/zone_mapper/manifest.json
+++ b/custom_components/zone_mapper/manifest.json
@@ -10,5 +10,5 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ApolloAutomation/zone-mapper/issues",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Added step in `__init__.py` to remove zone_mapper entities when the integration is uninstalled. Added filtering to ignore (0,0) coordinate pairs. Made `binary_sensor.py` update target coordinate step async instead of batched. This should hopefully improve the small delay between when a target enters a zone and the presence boolean updates. Bumped version and fixed license name from fork. **NOT BREAKING** but new release required to push to HACS users.
## Related Issue

<!-- If this PR fixes an issue, please link to the issue here -->

Fixes #(issue)

## Type of Change

<!-- Please delete options that are not relevant -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update
- [X] Code quality improvements

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] My code follows the code style of this project (run `scripts/lint`)
- [X] I have updated the documentation accordingly
- [X] I have updated the translations if needed

## Testing

<!-- Please describe how you tested your changes -->
Built and tested in Home Assistant Dev Container with no issues.
## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
